### PR TITLE
Replace exists() with existsSync() because it is deprecated.

### DIFF
--- a/lib/analysis_component.coffee
+++ b/lib/analysis_component.coffee
@@ -38,7 +38,7 @@ class AnalysisComponent extends Model
 
   isDartProject: =>
     pubspec = atom.project.getRootDirectory().getFile('pubspec.yaml')
-    pubspec.exists()
+    pubspec.existsSync()
 
   watchDartProject: =>
     @cleanup()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -39,7 +39,7 @@ class Utils
 
   @isDartProject: =>
     pubspec = atom.project.getRootDirectory().getFile('pubspec.yaml')
-    pubspec.exists()
+    pubspec.existsSync()
 
   @isDartFile: (filename = '') =>
     path.extname(filename) == '.dart'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/radicaled/dart-tools",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.127.0"
+    "atom": ">=0.180.0"
   },
   "constributors": [
     "Arron Washington <arron@theradicaledwards.com>"
@@ -18,7 +18,7 @@
     "react-atom-fork": "~0.10.0",
     "reactionary-atom-fork": "~0.9.0",
     "stream-splitter": "~0.3.0",
-    "pathwatcher": "~2.0.7",
+    "pathwatcher": "3.3.1",
     "q": "^1.0.1"
   }
 }


### PR DESCRIPTION
This deprecation was introduced in pathwatcher 3.3.0:
https://github.com/atom/node-pathwatcher/commit/6d6f2666dabe581111808a8cbe856d8429f0f21b

Atom started pulling in pathwatcher 3.3.1 in version 0.180.0:
https://github.com/atom/atom/commit/c260a29434547493d5f22508e2afd2da96f13f40