### PR TITLE
make the errors view slightly smaller

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -10,7 +10,7 @@
     'name': 'meta.preprocessor.script.dart'
   }
   {
-    'begin': '\\b(library|import|part of|part)\\b'
+    'begin': '\\b(library|import|part of|part|export)\\b'
     'beginCaptures':
       '0':
         'name': 'keyword.other.import.dart'
@@ -117,7 +117,7 @@
         'name': 'keyword.cast.dart'
       }
       {
-        'match': '\\b(try|catch|finally|throw)\\b'
+        'match': '\\b(try|catch|finally|throw|rethrow)\\b'
         'name': 'keyword.control.catch-exception.dart'
       }
       {

--- a/lib/analysis/analysis_toolbar.html
+++ b/lib/analysis/analysis_toolbar.html
@@ -1,17 +1,17 @@
 <atom-panel id='analysis-toolbar' class='from-bottom' rv-if="it.shouldShow">
-  <div class="padded container">
+  <div class="container">
     <h6>Dart Tools</h6>
     <div class='status'>
       <span rv-unless="it.hasProblems < errorCount warningCount">
         <i class="icon-check"></i> Everything is A OK!
       </span>
       <span rv-if="it.hasProblems < errorCount warningCount">
-        <button class="btn text-error" rv-on-click="it.showProblems">
+        <a class="text-error" rv-on-click="it.showProblems">
           <span rv-text="it.errorCount"
             class="">
           </span>
           errors
-        </button>
+        </a>
       </span>
     </div>
   </div>


### PR DESCRIPTION
![screen shot 2015-05-21 at 7 46 03 pm](https://cloud.githubusercontent.com/assets/1269969/7763192/4565d664-fff2-11e4-8847-83ff9d9ec95f.png)

Address #30 - make the errors view slightly smaller (and add some missing keywords to the grammar).