### PR TITLE
add pub upgrade; change sdk info labels; adjust error view size

### DIFF
--- a/lib/analysis/analysis_toolbar.html
+++ b/lib/analysis/analysis_toolbar.html
@@ -1,16 +1,13 @@
 <atom-panel id='analysis-toolbar' class='from-bottom' rv-if="it.shouldShow">
-  <div class="container">
+  <div class="container" style="padding-left: 12.5px; padding-right: 12.5px">
     <h6>Dart Tools</h6>
     <div class='status'>
       <span rv-unless="it.hasProblems < errorCount warningCount">
         <i class="icon-check"></i> Everything is A OK!
       </span>
       <span rv-if="it.hasProblems < errorCount warningCount">
-        <a class="text-error" rv-on-click="it.showProblems">
-          <span rv-text="it.errorCount"
-            class="">
-          </span>
-          errors
+        <a class="text-warning" rv-on-click="it.showProblems">
+          <span rv-text="it.errorCount" class=""> </span> issues
         </a>
       </span>
     </div>

--- a/lib/pub/pub_component.coffee
+++ b/lib/pub/pub_component.coffee
@@ -16,6 +16,8 @@ class PubComponent
 
     atom.commands.add 'atom-workspace', 'dart-tools:pub-get', =>
       @get()
+    atom.commands.add 'atom-workspace', 'dart-tools:pub-upgrade', =>
+      @upgrade()
 
   run: (args) =>
     process = @dartTools.runPubCommand('pub', args)
@@ -33,6 +35,12 @@ class PubComponent
       @emitter.emit 'pub-start',
         title: 'Pub Get'
       @run 'get'
+
+  upgrade: =>
+    @dartTools.withSdk =>
+      @emitter.emit 'pub-start',
+        title: 'Pub Upgrade'
+      @run 'upgrade'
 
   observePubspec: =>
     return unless Utils.isDartProject()

--- a/lib/sdk/sdk_info.coffee
+++ b/lib/sdk/sdk_info.coffee
@@ -6,14 +6,14 @@ class SdkInfo
     @view = new View()
 
   showInfo: (sdkInfo) =>
-    @view.version = sdkInfo.sdkPath || '(null)'
-    @view.currentSdk = sdkInfo.version || '(null)'
+    @view.sdkPath = sdkInfo.sdkPath || '(null)'
+    @view.sdkVersion = sdkInfo.version || '(null)'
     @view.show()
 
 class View
   shouldShow: false
-  version: null
-  currentSdk: null
+  sdkPath: null
+  sdkVersion: null
 
   constructor: ->
     element = Template.get('sdk/sdk_info.html')

--- a/lib/sdk/sdk_info.html
+++ b/lib/sdk/sdk_info.html
@@ -8,11 +8,11 @@
         <h2>Dart SDK Information</h2>
       </div>
       <div class="panel-body padded">
-        <h3>Current SDK Path</h3>
-        <p>{ it.currentSdk }</p>
+        <h3>SDK path</h3>
+        <p>{ it.sdkPath }</p>
 
-        <h3>Current SDK</h3>
-        <p>{ it.version }</p>
+        <h3>SDK version</h3>
+        <p>{ it.sdkVersion }</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- more size tweaks to the error panel
- correct some (reversed) labels in the sdk info dialog
- add a `pub upgrade` command

![screen shot 2015-05-21 at 9 35 15 pm](https://cloud.githubusercontent.com/assets/1269969/7764173/c07a5e6a-0001-11e5-82e0-633349d512f3.png)
![screen shot 2015-05-21 at 9 35 36 pm](https://cloud.githubusercontent.com/assets/1269969/7764174/c07ebf64-0001-11e5-82bc-cd6df3f702db.png)
![screen shot 2015-05-21 at 9 35 49 pm](https://cloud.githubusercontent.com/assets/1269969/7764175/c0800126-0001-11e5-8bb0-a02972f1d598.png)

fix #31