### PR TITLE
workaround exception; lint coffeescript files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Available Commands
 ==================
 
 * Pub Get
+* Pub Upgrade
 * Sdk Info
 * Format Code
 

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,122 @@
+{
+    "arrow_spacing": {
+        "level": "ignore"
+    },
+    "braces_spacing": {
+        "level": "ignore",
+        "spaces": 0,
+        "empty_object_spaces": 0
+    },
+    "camel_case_classes": {
+        "level": "error"
+    },
+    "coffeescript_error": {
+        "level": "error"
+    },
+    "colon_assignment_spacing": {
+        "level": "ignore",
+        "spacing": {
+            "left": 0,
+            "right": 0
+        }
+    },
+    "cyclomatic_complexity": {
+        "value": 10,
+        "level": "ignore"
+    },
+    "duplicate_key": {
+        "level": "error"
+    },
+    "empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "ensure_comprehensions": {
+        "level": "warn"
+    },
+    "indentation": {
+        "value": 2,
+        "level": "error"
+    },
+    "line_endings": {
+        "level": "ignore",
+        "value": "unix"
+    },
+    "max_line_length": {
+        "value": 80,
+        "level": "warn",
+        "limitComments": true
+    },
+    "missing_fat_arrows": {
+        "level": "ignore",
+        "is_strict": false
+    },
+    "newlines_after_classes": {
+        "value": 3,
+        "level": "ignore"
+    },
+    "no_backticks": {
+        "level": "error"
+    },
+    "no_debugger": {
+        "level": "warn"
+    },
+    "no_empty_functions": {
+        "level": "ignore"
+    },
+    "no_empty_param_list": {
+        "level": "ignore"
+    },
+    "no_implicit_braces": {
+        "level": "ignore",
+        "strict": true
+    },
+    "no_implicit_parens": {
+        "strict": true,
+        "level": "ignore"
+    },
+    "no_interpolation_in_single_quotes": {
+        "level": "ignore"
+    },
+    "no_plusplus": {
+        "level": "ignore"
+    },
+    "no_stand_alone_at": {
+        "level": "ignore"
+    },
+    "no_tabs": {
+        "level": "error"
+    },
+    "no_throwing_strings": {
+        "level": "error"
+    },
+    "no_trailing_semicolons": {
+        "level": "error"
+    },
+    "no_trailing_whitespace": {
+        "level": "error",
+        "allowed_in_comments": false,
+        "allowed_in_empty_lines": true
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "ignore"
+    },
+    "no_unnecessary_fat_arrows": {
+        "level": "warn"
+    },
+    "non_empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "prefer_english_operator": {
+        "level": "ignore",
+        "doubleNotLevel": "ignore"
+    },
+    "space_operators": {
+        "level": "ignore"
+    },
+    "spacing_after_comma": {
+        "level": "ignore"
+    },
+    "transform_messes_up_line_numbers": {
+        "level": "warn"
+    }
+}

--- a/lib/analysis/analysis_toolbar.coffee
+++ b/lib/analysis/analysis_toolbar.coffee
@@ -29,18 +29,18 @@ class AnalysisToolbar
     totalInfo     = 0
     for path, errors of @errors.repository
       totalProblems += errors.length
-      
-      # totalInfo     += _.sum errors, (p) =>
-      #   if AnalysisToolbar.infoTypes.indexOf(p.type) != -1 then 1 else 0
-      #
-      # totalWarnings += _.sum errors, (p) =>
-      #   if AnalysisToolbar.warningTypes.indexOf(p.type) != -1 then 1 else 0
-      #
-      # totalErrors   += _.sum errors, (p) =>
-      #   isInfo    = AnalysisToolbar.infoTypes.indexOf(p.type) != -1
-      #   isWarning = AnalysisToolbar.warningTypes.indexOf(p.type) != -1
-      #
-      #   if !isInfo && !isWarning then 1 else 0
+
+      totalInfo     += _.sum errors, (p) =>
+        if AnalysisToolbar.infoTypes.indexOf(p.type) != -1 then 1 else 0
+
+      totalWarnings += _.sum errors, (p) =>
+        if AnalysisToolbar.warningTypes.indexOf(p.type) != -1 then 1 else 0
+
+      totalErrors   += _.sum errors, (p) =>
+        isInfo    = AnalysisToolbar.infoTypes.indexOf(p.type) != -1
+        isWarning = AnalysisToolbar.warningTypes.indexOf(p.type) != -1
+
+        if !isInfo && !isWarning then 1 else 0
 
     @view.problemCount  = totalProblems
     @view.infoCount     = totalInfo

--- a/lib/analysis/analysis_toolbar.coffee
+++ b/lib/analysis/analysis_toolbar.coffee
@@ -29,18 +29,18 @@ class AnalysisToolbar
     totalInfo     = 0
     for path, errors of @errors.repository
       totalProblems += errors.length
-
-      totalInfo     += _.sum errors, (p) =>
-        if AnalysisToolbar.infoTypes.indexOf(p.type) != -1 then 1 else 0
-
-      totalWarnings += _.sum errors, (p) =>
-        if AnalysisToolbar.warningTypes.indexOf(p.type) != -1 then 1 else 0
-
-      totalErrors   += _.sum errors, (p) =>
-        isInfo    = AnalysisToolbar.infoTypes.indexOf(p.type) != -1
-        isWarning = AnalysisToolbar.warningTypes.indexOf(p.type) != -1
-
-        if !isInfo && !isWarning then 1 else 0
+      
+      # totalInfo     += _.sum errors, (p) =>
+      #   if AnalysisToolbar.infoTypes.indexOf(p.type) != -1 then 1 else 0
+      #
+      # totalWarnings += _.sum errors, (p) =>
+      #   if AnalysisToolbar.warningTypes.indexOf(p.type) != -1 then 1 else 0
+      #
+      # totalErrors   += _.sum errors, (p) =>
+      #   isInfo    = AnalysisToolbar.infoTypes.indexOf(p.type) != -1
+      #   isWarning = AnalysisToolbar.warningTypes.indexOf(p.type) != -1
+      #
+      #   if !isInfo && !isWarning then 1 else 0
 
     @view.problemCount  = totalProblems
     @view.infoCount     = totalInfo

--- a/lib/analysis_result.coffee
+++ b/lib/analysis_result.coffee
@@ -15,4 +15,4 @@ class AnalysisResult
     result.column   = parseInt segments[5]
     result.length   = parseInt segments[6]
     result.desc     = segments[7]
-    return result    
+    return result

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -13,8 +13,8 @@ module.exports =
     #   type: 'boolean'
     #   default: false
     formatOnSave:
-        type: 'boolean'
-        default: true
+      type: 'boolean'
+      default: true
     dartSdkLocation:
       type: 'string'
       default: ''

--- a/lib/formatter.coffee
+++ b/lib/formatter.coffee
@@ -65,7 +65,7 @@ class Formatter
 
       if response.error
         @signalError(response.error)
-        return;
+        return
 
       @applyEdits(editor, result.edits)
       @updateCaretPosition(editor, result.selectionOffset, result.selectionLength)
@@ -73,13 +73,13 @@ class Formatter
   # Event Handlers
 
   formatOnSave: (editor) =>
-    formatting = false;
+    formatting = false
     @editorSubscriptions.add editor.onDidSave =>
-      return if formatting;
-      formatting = true;
+      return if formatting
+      formatting = true
       @formatEditor(editor).then () =>
-        editor.save();
-        formatting = false;
+        editor.save()
+        formatting = false
 
 
   # Broken(ish).

--- a/lib/info/problem_view.coffee
+++ b/lib/info/problem_view.coffee
@@ -70,7 +70,7 @@ class ProblemViewElement extends HTMLElement
     "Dart: Problems"
 
   navigateToProblem: (event) =>
-    target = event.currentTarget;
+    target = event.currentTarget
     file = target.getAttribute('data-file')
     line = target.getAttribute('data-line') - 1
     col  = target.getAttribute('data-col') - 1

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -8,7 +8,7 @@ class Utils
     dart: 'dart.exe'
 
   @getExecutable: (cmd) =>
-    isWin = /^win/.test(process.platform);
+    isWin = /^win/.test(process.platform)
     return cmd unless isWin
     windowsCmd = @windowsCmdMap[cmd]
     return windowsCmd || cmd
@@ -43,7 +43,7 @@ class Utils
     execPath = @getExecPath 'dart'
     @whenDartSdkFound =>
       process = spawn execPath, ['--version']
-      exitCode = -1;
+      exitCode = -1
 
       process.stderr.on 'data', (data) => buffer += data.toString()
       process.stderr.on 'end', => fxn(buffer)

--- a/lib/views/analysis_view.coffee
+++ b/lib/views/analysis_view.coffee
@@ -59,8 +59,8 @@ class AnalysisResultRow extends View
         @text @analysisText(analysisResult)
 
   @analysisText: (analysisResult) ->
-     loc = analysisResult.location
-     "#{loc.file}:#{loc.startLine}: #{analysisResult.message}"
+    loc = analysisResult.location
+    "#{loc.file}:#{loc.startLine}: #{analysisResult.message}"
 
   gotoAnalysis: =>
     loc = @analysisResult.location


### PR DESCRIPTION
- add a coffeescript lint file. It has some coffeelint warnings about use of `->`, but I'm not sure if they're accurate or not -
- lint nits about semicolons, indent, and trailing whitespace
- commented out a block of code which was throwing an exception (`lib/analysis/analysis_toolbar.coffee`)

I'll file an issue about the exception for more context -