### PR TITLE
more lints

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -29,7 +29,7 @@
     "level": "error"
   },
   "no_unnecessary_fat_arrows": {
-    "comment": "Changed from the Atom standard coffeelint file",
+    "comment": "Changed from the Atom standard coffeelint file (was error)",
     "level": "ignore"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,122 +1,35 @@
 {
-    "arrow_spacing": {
-        "level": "ignore"
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "error"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
+  },
+  "no_debugger": {
+    "level": "error"
+  },
+  "prefer_english_operator": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "spacing": {
+      "left": 0,
+      "right": 1
     },
-    "braces_spacing": {
-        "level": "ignore",
-        "spaces": 0,
-        "empty_object_spaces": 0
-    },
-    "camel_case_classes": {
-        "level": "error"
-    },
-    "coffeescript_error": {
-        "level": "error"
-    },
-    "colon_assignment_spacing": {
-        "level": "ignore",
-        "spacing": {
-            "left": 0,
-            "right": 0
-        }
-    },
-    "cyclomatic_complexity": {
-        "value": 10,
-        "level": "ignore"
-    },
-    "duplicate_key": {
-        "level": "error"
-    },
-    "empty_constructor_needs_parens": {
-        "level": "ignore"
-    },
-    "ensure_comprehensions": {
-        "level": "warn"
-    },
-    "indentation": {
-        "value": 2,
-        "level": "error"
-    },
-    "line_endings": {
-        "level": "ignore",
-        "value": "unix"
-    },
-    "max_line_length": {
-        "value": 80,
-        "level": "warn",
-        "limitComments": true
-    },
-    "missing_fat_arrows": {
-        "level": "ignore",
-        "is_strict": false
-    },
-    "newlines_after_classes": {
-        "value": 3,
-        "level": "ignore"
-    },
-    "no_backticks": {
-        "level": "error"
-    },
-    "no_debugger": {
-        "level": "warn"
-    },
-    "no_empty_functions": {
-        "level": "ignore"
-    },
-    "no_empty_param_list": {
-        "level": "ignore"
-    },
-    "no_implicit_braces": {
-        "level": "ignore",
-        "strict": true
-    },
-    "no_implicit_parens": {
-        "strict": true,
-        "level": "ignore"
-    },
-    "no_interpolation_in_single_quotes": {
-        "level": "ignore"
-    },
-    "no_plusplus": {
-        "level": "ignore"
-    },
-    "no_stand_alone_at": {
-        "level": "ignore"
-    },
-    "no_tabs": {
-        "level": "error"
-    },
-    "no_throwing_strings": {
-        "level": "error"
-    },
-    "no_trailing_semicolons": {
-        "level": "error"
-    },
-    "no_trailing_whitespace": {
-        "level": "error",
-        "allowed_in_comments": false,
-        "allowed_in_empty_lines": true
-    },
-    "no_unnecessary_double_quotes": {
-        "level": "ignore"
-    },
-    "no_unnecessary_fat_arrows": {
-        "level": "warn"
-    },
-    "non_empty_constructor_needs_parens": {
-        "level": "ignore"
-    },
-    "prefer_english_operator": {
-        "level": "ignore",
-        "doubleNotLevel": "ignore"
-    },
-    "space_operators": {
-        "level": "ignore"
-    },
-    "spacing_after_comma": {
-        "level": "ignore"
-    },
-    "transform_messes_up_line_numbers": {
-        "level": "warn"
-    }
+    "level": "error"
+  },
+  "braces_spacing": {
+    "spaces": 0,
+    "level": "error"
+  },
+  "no_unnecessary_fat_arrows": {
+    "comment": "Changed from the Atom standard coffeelint file",
+    "level": "ignore"
+  }
 }

--- a/lib/autocomplete/provider.coffee
+++ b/lib/autocomplete/provider.coffee
@@ -45,7 +45,7 @@ AutoCompletePlusProvider =
             # Both "XmlDocument" and "XmlName" have the same relevance score
             # for the fragment "XmlDocumen"
             if prefix != "."
-              sortedResults = filter(results, prefix, { key: 'completion'})
+              sortedResults = filter(results, prefix, {key: 'completion'})
 
             for result in sortedResults
               items.push

--- a/lib/formatter.coffee
+++ b/lib/formatter.coffee
@@ -77,7 +77,7 @@ class Formatter
     @editorSubscriptions.add editor.onDidSave =>
       return if formatting
       formatting = true
-      @formatEditor(editor).then () =>
+      @formatEditor(editor).then =>
         editor.save()
         formatting = false
 

--- a/lib/pub/pub_component.coffee
+++ b/lib/pub/pub_component.coffee
@@ -8,7 +8,7 @@ Utils = require '../utils'
 PubStatusView = require './pub_status_view'
 
 class PubComponent
-  constructor: () ->
+  constructor: ->
     @emitter = new Emitter
     @pubStatusView = new PubStatusView(this)
     @watchers = []


### PR DESCRIPTION
- use the coffeescript lints from the main atom project (https://github.com/atom/atom/blob/master/coffeelint.json)
- some edits based on lint findings

Most of the remaining lints are to do with using `or` instead of `||` - using the more english word style comparison operators.