### PR TITLE
initial support for building on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: objective-c
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+git:
+  depth: 10
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dart-tools package
 
+[![Build Status](https://travis-ci.org/radicaled/dart-tools.svg?branch=master)][travis]
+
 Various tools for Dart support in Atom.
 
 **NOTE**: somewhat alpha quality
@@ -29,15 +31,18 @@ Notes
 
 Formatting will save the current editor buffer first.
 
-**Linting requires you to set your dart-sdk location.** You can do from
-Settings View: Open -> Filter Packages -> Dart Tools.
+**Linting requires you to set your dart-sdk location.** You can do that from
+`Settings View: Open` -> `Filter Packages` -> `Dart Tools`.
 
 Linting will not be performed until you have run `pub get` at least once.
 
-Performance: `dart-tools` doesn't handle a large number of errors very well -- around 300 errors starts slowing things down. Take care with your refactoring until this is resolved!
-
+Performance: `dart-tools` doesn't handle a large number of errors very well -
+around 300 errors starts slowing things down. Take care with your refactoring
+until this is resolved!
 
 Credits
 =======
 
 dart.cson taken from https://github.com/Daegalus/atom-language-dart (dead?) and modified.
+
+[travis]: https://travis-ci.org/radicaled/dart-tools


### PR DESCRIPTION
Some initial support for building on travis. You'd still need to configure the the github hook for travis. But this will get the code being linted, and any tests put into `spec/` _should_ run.