### PR TITLE
change the prefer_english_operator lint to a warn from an error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# See editorconfig.org.
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -14,9 +14,6 @@
   "no_debugger": {
     "level": "error"
   },
-  "prefer_english_operator": {
-    "level": "error"
-  },
   "colon_assignment_spacing": {
     "spacing": {
       "left": 0,
@@ -28,8 +25,14 @@
     "spaces": 0,
     "level": "error"
   },
+
+
   "no_unnecessary_fat_arrows": {
     "comment": "Changed from the Atom standard coffeelint file (was error)",
     "level": "ignore"
+  },
+  "prefer_english_operator": {
+    "comment": "Changed from the Atom standard coffeelint file (was error)",
+    "level": "warn"
   }
 }

--- a/lib/analysis/analysis_decorator.coffee
+++ b/lib/analysis/analysis_decorator.coffee
@@ -31,7 +31,7 @@ class AnalysisDecorator
       line      = location.startLine - 1
       column    = location.startColumn - 1
       css       = "dart-analysis-#{category}"
-      marker   = editor.markBufferRange [
+      marker    = editor.markBufferRange [
         [line, column],
         [line, column + location.length]
       ]
@@ -49,7 +49,7 @@ class AnalysisDecorator
   handleErrors: ({file, errors, added, removed}) =>
     for editor in atom.workspace.getTextEditors()
       fullPath = editor.getPath()
-      if fullPath == file
+      if fullPath is file
         @clearMarkers(editor, removed)
         @decorateEditor(editor, added)
         return

--- a/lib/analysis_component.coffee
+++ b/lib/analysis_component.coffee
@@ -36,7 +36,7 @@ class AnalysisComponent
     @cleanup()
 
   checkFile: (fullPath) =>
-    if extname(fullPath) == '.dart'
+    if extname(fullPath) is '.dart'
       @analysisServer.check(fullPath)
 
   cleanup: =>

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -47,7 +47,9 @@ class AnalysisServer
             After #{@FAILURE_HARD_STOP} tries within #{@FAILURE_HARD_STOP_TIMEOUT * 1000} seconds,
             the analysis server failed to start.
           "
-          atom.notifications.addError("[dart-tools] The analysis server failed to start after several tries.", detail: detail)
+          atom.notifications.addError(
+            "[dart-tools] The analysis server failed to start after several tries.",
+            detail: detail)
 
       # Set analysis root.
       @setAnalysisRoots analysisRoots


### PR DESCRIPTION
- add an editorconfig file
- change the `prefer_english_operator` lint to a warn from an error
- address some misc lints