### PR TITLE
On demand activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.12
+
+Features:
+  * Now supports analyzing plain jane Dart files when possible.
+
 # 0.9.11
 
 Features:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Formatting will save the current editor buffer first.
 **Linting requires you to set your dart-sdk location.** You can do that from
 `Settings View: Open` -> `Filter Packages` -> `Dart Tools`.
 
-Linting will not be performed until you have run `pub get` at least once.
+If you have a `pubspec.yaml` file or `.packages` path in your project, linting
+will begin immediately. If not, linting will begin once you open a Dart file
+that exists within your current project scope.
 
 Performance: `dart-tools` doesn't handle a large number of errors very well -
 around 300 errors starts slowing things down. Take care with your refactoring

--- a/lib/analysis_component.coffee
+++ b/lib/analysis_component.coffee
@@ -17,18 +17,17 @@ class AnalysisComponent
 
   constructor: ->
     @emitter = new Emitter()
-
-  enable: =>
-    return unless Utils.isDartProject()
-
-    dartProjectPaths = Utils.getDartProjectPaths()
     @analysisServer = new AnalysisServer()
     @analysisAPI.analysisServer = @analysisServer
+
+  enable: =>
+    dartProjectPaths = Utils.getDartProjectPaths()
+
     @analysisServer.start dartProjectPaths
 
     @subscriptions.push atom.project.onDidChangePaths @handleProjectPaths
 
-    atom.workspace.observeTextEditors (editor) =>
+    @subscriptions.push atom.workspace.observeTextEditors (editor) =>
       buc = new BufferUpdateComponent(editor, @analysisAPI)
       editor.onDidDestroy => buc.destroy()
 

--- a/lib/analysis_component.coffee
+++ b/lib/analysis_component.coffee
@@ -35,10 +35,6 @@ class AnalysisComponent
   disable: =>
     @cleanup()
 
-  checkFile: (fullPath) =>
-    if extname(fullPath) is '.dart'
-      @analysisServer.check(fullPath)
-
   cleanup: =>
     subscription.dispose() for subscription in @subscriptions
     @subscriptions = []

--- a/lib/analysis_component.coffee
+++ b/lib/analysis_component.coffee
@@ -52,6 +52,3 @@ class AnalysisComponent
     # Naively assuming that analysis_server will ensure that the project paths
     # have changed before invalidating everything...
     @analysisServer.setAnalysisRoots dartProjectPaths
-
-  showProblems: =>
-    console.log 'showing problems'

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -10,7 +10,7 @@ module.exports =
 class AnalysisServer
   id: 1
   promiseMap = {}
-  writable: false
+  isRunning: false
 
   constructor: ->
     @emitter = new Emitter()
@@ -28,10 +28,10 @@ class AnalysisServer
     cmd = Utils.getExecPath 'dart'
     Utils.whenDartSdkFound =>
       @process = spawn cmd, args
-      @writable = true
+      @isRunning = true
       @process.stdout.pipe(StreamSplitter("\n")).on 'token', @processMessage
       @process.on 'exit', =>
-        @writable = false
+        @isRunning = false
 
       # Set analysis root.
       @setAnalysisRoots analysisRoots
@@ -42,7 +42,7 @@ class AnalysisServer
   sendMessage: (obj) =>
     obj.id ||= "dart-tools-#{(@id++)}"
     msg = JSON.stringify(obj)
-    if @writable
+    if @isRunning
       @process?.stdin?.write(msg + "\n")
 
     deferred = Q.defer()

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -8,11 +8,8 @@ Q = require 'q'
 
 module.exports =
 class AnalysisServer
-  FAILURE_HARD_STOP: 3
-  FAILURE_HARD_STOP_TIMEOUT: 30
   id: 1
   promiseMap = {}
-  serverFailureCount: 0
   writable: false
 
   constructor: ->
@@ -35,21 +32,6 @@ class AnalysisServer
       @process.stdout.pipe(StreamSplitter("\n")).on 'token', @processMessage
       @process.on 'exit', =>
         @writable = false
-        @serverFailureCount += 1
-
-        setTimeout (=> @serverFailureCount = 0), @FAILURE_HARD_STOP_TIMEOUT * 1000
-
-
-        if @serverFailureCount < @FAILURE_HARD_STOP
-          @start()
-        else
-          detail = "
-            After #{@FAILURE_HARD_STOP} tries within #{@FAILURE_HARD_STOP_TIMEOUT * 1000} seconds,
-            the analysis server failed to start.
-          "
-          atom.notifications.addError(
-            "[dart-tools] The analysis server failed to start after several tries.",
-            detail: detail)
 
       # Set analysis root.
       @setAnalysisRoots analysisRoots

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -11,6 +11,7 @@ class AnalysisServer
   id: 1
   promiseMap = {}
   isRunning: false
+  currentAnalysisRoots: new Set()
 
   constructor: ->
     @emitter = new Emitter()
@@ -80,6 +81,7 @@ class AnalysisServer
       callback(obj.event, obj)
 
   setAnalysisRoots: (paths) =>
+    @currentAnalysisRoots = new Set(paths)
     @sendMessage
       method: "analysis.setAnalysisRoots"
       params:

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -39,16 +39,6 @@ class AnalysisServer
   stop: =>
     @process?.close()
 
-  # Not sure this method is needed, but adding for
-  # compatibility
-  check: (fullPath) =>
-    @emit 'refresh', fullPath
-    @sendMessage
-      method: "analysis.reanalyze"
-      params:
-        file: fullPath
-
-
   sendMessage: (obj) =>
     obj.id ||= "dart-tools-#{(@id++)}"
     msg = JSON.stringify(obj)

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -40,10 +40,10 @@ class AnalysisServer
     @process?.close()
 
   sendMessage: (obj) =>
+    return unless @isRunning
     obj.id ||= "dart-tools-#{(@id++)}"
     msg = JSON.stringify(obj)
-    if @isRunning
-      @process?.stdin?.write(msg + "\n")
+    @process.stdin.write(msg + "\n")
 
     deferred = Q.defer()
     promiseMap[obj.id] = deferred

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -117,6 +117,7 @@ class DartTools
     @analysisDecorator?.dispose()
     @quickInfoView?.dispose()
 
+# TODO: move this out into "init.coffee" or "main.coffee"
 module.exports =
 
   # Wizardry

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -44,9 +44,6 @@ class DartTools
 
       enableAnalyzer(editor)
 
-    return unless Utils.isDartProject()
-    @boot()
-
   # TODO: becoming massive, refactor.
   boot: =>
     return if @hasBooted

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -1,33 +1,56 @@
 {CompositeDisposable} = require 'atom'
 Utils = require './utils'
 AutoCompletePlusProvider = require './autocomplete/provider'
+_ = require 'lodash'
 
-module.exports =
+class DartTools
+  subscriptions: new CompositeDisposable()
+  hasBooted: false
 
-  # Wizardry
-  config:
-    pubGetOnSave:
-      type: 'boolean'
-      default: true
-    # automaticFormat:
-    #   type: 'boolean'
-    #   default: false
-    formatOnSave:
-      type: 'boolean'
-      default: true
-    dartSdkLocation:
-      type: 'string'
-      default: ''
+  constructor: ->
+    AnalysisComponent = require './analysis_component'
+    @analysisComponent = new AnalysisComponent()
+    @analysisApi = @analysisComponent.analysisAPI
 
-  # Provider for `autocomplete-plus`
-  provideAutocompleter: ->
-    AutoCompletePlusProvider
+  waitForDartSources: =>
+    analysisServer = @analysisComponent.analysisServer
+    # Trigger analysis server if we're in a plain-jane Dart project
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      enableAnalyzer = (editor) =>
+        return unless Utils.canAnalyze(editor)
 
+        projectPath = Utils.findProjectRootInAtom(editor.getPath())
+        roots = @analysisComponent.analysisServer.currentAnalysisRoots
+
+        array = []
+        perform = =>
+          analysisServer.setAnalysisRoots array
+
+        return if roots.has(projectPath)
+
+        roots.add(projectPath)
+        roots.forEach (e) => array.push(e)
+
+        if analysisServer.isRunning
+          perform()
+        else
+          sub = @analysisApi.on 'server.connected', =>
+            perform()
+            sub.dispose()
+        @boot()
+
+      editor.onDidChangePath (path) =>
+        enableAnalyzer(editor)
+
+      enableAnalyzer(editor)
+
+    return unless Utils.isDartProject()
+    @boot()
 
   # TODO: becoming massive, refactor.
-  activate: (state) ->
-    @subscriptions = new CompositeDisposable()
-    return unless Utils.isDartProject()
+  boot: =>
+    return if @hasBooted
+    @hasBooted = true
 
     # HACK: for some reason Atom is saving every dart-tools marker
     # This code flushes all pre-existing markers...
@@ -36,9 +59,6 @@ module.exports =
         isDartMarker: true
       marker.destroy() for marker in markers
 
-    # Status updates for analysis server
-
-    AnalysisComponent = require './analysis_component'
     Formatter = require './formatter'
     PubComponent = require './pub/pub_component'
     DartExplorerComponent = require './dart_explorer/dart_explorer_component'
@@ -48,9 +68,6 @@ module.exports =
     AnalysisDecorator = require './analysis/analysis_decorator'
     QuickInfoView = require './info/quick_info_view'
     ProblemView = require './info/problem_view'
-
-    @analysisComponent = new AnalysisComponent()
-    @analysisApi = @analysisComponent.analysisAPI
 
     @errorRepository = new ErrorRepository(@analysisApi)
     @analysisToolbar = new AnalysisToolbar(@errorRepository)
@@ -97,8 +114,39 @@ module.exports =
 
     atom.commands.add 'atom-workspace', 'dart-tools:toggle-analysis-view'
 
-  deactivate: ->
+  dispose: =>
     @subscriptions?.dispose()
     @analysisComponent?.disable()
     @analysisDecorator?.dispose()
     @quickInfoView?.dispose()
+
+module.exports =
+
+  # Wizardry
+  config:
+    pubGetOnSave:
+      type: 'boolean'
+      default: true
+    # automaticFormat:
+    #   type: 'boolean'
+    #   default: false
+    formatOnSave:
+      type: 'boolean'
+      default: true
+    dartSdkLocation:
+      type: 'string'
+      default: ''
+
+  # Provider for `autocomplete-plus`
+  provideAutocompleter: ->
+    AutoCompletePlusProvider
+
+  activate: (state) ->
+    @dartTools = new DartTools()
+    @dartTools.waitForDartSources()
+
+    return unless Utils.isDartProject()
+    @dartTools.boot()
+
+  deactivate: ->
+    @dartTools.dispose()

--- a/lib/pub/pub_component.coffee
+++ b/lib/pub/pub_component.coffee
@@ -60,15 +60,17 @@ class PubComponent
 
   get: =>
     Utils.dartSdkInfo =>
-      @emitter.emit 'pub-start',
-        title: 'Pub Get'
-      @run 'get'
+      @whenPubspecPresent =>
+        @emitter.emit 'pub-start',
+          title: 'Pub Get'
+        @run 'get'
 
   upgrade: =>
     Utils.dartSdkInfo =>
-      @emitter.emit 'pub-start',
-        title: 'Pub Upgrade'
-      @run 'upgrade'
+      @whenPubspecPresent =>
+        @emitter.emit 'pub-start',
+          title: 'Pub Upgrade'
+        @run 'upgrade'
 
   observePubspec: (pubspecRoot) =>
     pubspecPath = path.join pubspecRoot, 'pubspec.yaml'
@@ -95,6 +97,15 @@ class PubComponent
 
   markAsStopped: (pubspecPath) =>
     delete @runningProcesses[pubspecPath]
+
+  # Helpers
+
+  whenPubspecPresent: (callback) =>
+    return unless Utils.getDartProjectPaths().length > 0
+    pubspecRoot = Utils.getDartProjectPaths()[0]
+    pubspecPath = path.join pubspecRoot, 'pubspec.yaml'
+    return unless fs.existsSync(pubspecPath)
+    callback()
 
   # Events
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -53,7 +53,7 @@ class Utils
     fxn() if @isDartProject()
 
   @isDartProject: =>
-    @getDartProjectPaths() isnt null
+    @getDartProjectPaths().length > 0
 
   @getDartProjectPaths: =>
     filter = (dir) ->
@@ -66,6 +66,17 @@ class Utils
   @isCompatible: (editor) =>
     # We only support pure Dart files for now
     @isDartFile editor.getPath()
+
+  @findProjectRootInAtom: (path) =>
+    directories = atom.project.getDirectories()
+    dir = _.find(directories, (d) => d.contains(path))
+    dir?.getPath()
+
+  @canAnalyze: (editor) =>
+    filename = editor.getPath()
+    projectPath = @findProjectRootInAtom(filename)
+
+    @isCompatible(editor) && projectPath
 
   @whenDartSdkFound: (fxn) =>
     # Why is process null??


### PR DESCRIPTION
dart-tools will boot up analysis server and attached GUI components on demand if a Dart file is opened but there is no `.packages` or `pubspec.yaml` path present.

Work on #23.