### PR TITLE
revise the errors display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Features:
   * Now supports analyzing plain jane Dart files when possible.
 
+General overhaul of the errors display:
+  * add a gutter bullet decoration for dart infos, warnings, and errors
+  * show the quick error view for any markers on the line (not just the selection)
+  * change the look of the quick info view of a dart issue
+  * change the highlight decorator to better call out errors (2px underline instead of 1px dotted)
+
 # 0.9.11
 
 Features:

--- a/lib/analysis/analysis_decorator.coffee
+++ b/lib/analysis/analysis_decorator.coffee
@@ -44,6 +44,9 @@ class AnalysisDecorator
       editor.decorateMarker marker,
         type: 'highlight',
         class: css
+      editor.decorateMarker marker,
+        type: 'line-number',
+        class: "dart-#{category}"
 
   # Event handlers
   handleErrors: ({file, errors, added, removed}) =>

--- a/lib/analysis/analysis_toolbar.html
+++ b/lib/analysis/analysis_toolbar.html
@@ -7,7 +7,7 @@
       </span>
       <span rv-if="it.problemCount">
         <a class="text-warning" rv-on-click="it.showProblems">
-          <span rv-text="it.problemCount" class=""> </span> issues
+          <span rv-text="it.problemCount"> </span> issues
         </a>
       </span>
     </div>

--- a/lib/info/problem_view.html
+++ b/lib/info/problem_view.html
@@ -3,7 +3,6 @@
 </div>
 
 <div class="padded">
-  
   <div rv-each-entry="it.problemList">
     <h3>
       <span class="icon icon-file-text"></span>

--- a/lib/info/quick_info_view.coffee
+++ b/lib/info/quick_info_view.coffee
@@ -28,8 +28,8 @@ class QuickInfoView
         @removeMarker(marker)
 
     @editorEvents.add editor.onDidChangeSelectionRange =>
-      selectedBufferRange = editor.getSelectedBufferRange()
-      markers = @findMarkersInRange(editor, selectedBufferRange)
+      range = editor.getSelectedBufferRange()
+      markers = @findMarkersOnRow(editor, range.start.row)
 
       @view.reset()
       @addMarker(marker) for marker in markers
@@ -50,9 +50,9 @@ class QuickInfoView
     if markerRange.containsRange(selectedBufferRange)
       callback(marker)
 
-  findMarkersInRange: (editor, range) =>
+  findMarkersOnRow: (editor, row) =>
     attrs =
-      containsBufferRange: range
+      startBufferRow: row
       isDartMarker: true
     markers = editor.findMarkers(attrs)
     _.where markers, (m) -> m.isValid()
@@ -78,7 +78,9 @@ class View
     atom.workspace.addBottomPanel(item: element)
     @view = rivets.bind(element, {it: this})
 
-    rivets.formatters.formattedProblem = @formattedProblem
+    rivets.binders.badge = @badge
+    rivets.formatters.formatProblemType = @formatProblemType
+    rivets.formatters.formatLocation = @formatLocation
     rivets.formatters.lowerCase = (s) -> if s then s.toLowerCase() else s
 
   addProblem: (problem) =>
@@ -91,7 +93,16 @@ class View
   reset: =>
     @problems = []
 
-  formattedProblem: (problem) ->
-    problem.message
+  formatProblemType: (str) ->
+    (str.replace new RegExp('_', 'g'), " ").toLowerCase()
+
+  formatLocation: (location) ->
+    "line #{location.startLine}, column #{location.startColumn}"
+
+  badge: (element, problem) ->
+    element.classList.remove("badge-info")
+    element.classList.remove("badge-warning")
+    element.classList.remove("badge-error")
+    element.classList.add("badge-#{problem.severity.toLowerCase()}")
 
 module.exports = QuickInfoView

--- a/lib/info/quick_info_view.html
+++ b/lib/info/quick_info_view.html
@@ -1,10 +1,15 @@
 <atom-panel id='quick-info-view' class='from-bottom' rv-if="it.shouldShow < problems">
   <div class="padded">
-    <div rv-each-problem="it.problems"
-      rv-class="problem.severity | lowerCase"
-      data-dart-analysis>
-      <span class="badge">Dart</span>
-      { problem | formattedProblem }
+    <div rv-each-problem="it.problems">
+      <div class="badge inline-block" rv-badge="problem">
+        dart: {problem.type | formatProblemType}
+      </div>
+      <div class="inline-block">
+        {problem.message}
+      </div>
+      <div class='inline-block text-subtle'>
+        {problem.location | formatLocation}
+      </div>
     </div>
   </div>
 </atom-panel>

--- a/styles/dart-tools.less
+++ b/styles/dart-tools.less
@@ -1,9 +1,8 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
+// The ui-variables file is provided by base themes provided by Atom. See
+// https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
 // for a full listing of what's available.
-@import "ui-variables";
-
+@import 'ui-variables';
+@import 'octicon-utf-codes';
 
 .dart-explorer {
   overflow: scroll;
@@ -49,48 +48,43 @@ html /deep/ * {
   }
 }
 
-
 ul.dart-tools-quick-issue-view {
   margin-bottom: 0;
 }
 
-html /deep/ #quick-info-view {
-  [data-dart-analysis] {
-    margin-bottom: 2px;
-  }
-  [data-dart-analysis] > span.badge {
-    margin-right: 10px;
-  }
+#quick-info-view .badge {
+  font-weight: normal;
+  text-shadow: none;
+  padding: 2px 6px;
 }
 
 html /deep/ #analysis-toolbar {
-    & > .container {
-      display: flex;
-      align-items: baseline;
+  & > .container {
+    display: flex;
+    align-items: baseline;
 
-      & > * {
-        margin-right: 15px;
-      }
+    & > * {
+      margin-right: 15px;
     }
+  }
 }
 
 atom-text-editor::shadow {
   .dart-analysis-info {
     .region {
-      border-bottom: 1px dotted fadeout(@text-color-info, 30%);
+      border-bottom: 2px solid @text-color-info;
     }
 
   }
   .dart-analysis-warning {
     .region {
-      border-bottom: 1px dotted fadeout(@text-color-warning, 30%);
+      border-bottom: 2px solid @text-color-warning;
     }
   }
 
-
   .dart-analysis-error {
     .region {
-      border-bottom: 1px dotted fadeout(@text-color-error, 30%);
+      border-bottom: 2px solid @text-color-error;
     }
   }
 }
@@ -108,6 +102,37 @@ dart-tools-problem-view {
 
     .line, .column {
       width: 80px;
+    }
+  }
+}
+
+// Gutter marker decorations.
+
+atom-text-editor::shadow .gutter .line-number {
+  &.dart-info .icon-right {
+    visibility: visible;
+    &:before {
+      color: @text-color-info;
+      content: @primitive-dot;
+      font-size: 1.1em;
+    }
+  }
+
+  &.dart-warning .icon-right {
+    visibility: visible;
+    &:before {
+      color: @text-color-warning;
+      content: @primitive-dot;
+      font-size: 1.1em;
+    }
+  }
+
+  &.dart-error .icon-right {
+    visibility: visible;
+    &:before {
+      color: @text-color-error;
+      content: @primitive-dot;
+      font-size: 1.1em;
     }
   }
 }


### PR DESCRIPTION
- add a gutter bullet decoration for dart infos, warnings, and errors
- show the quick error view for any markers on the line (not just the selection)
- change the quick info view of a dart issue (image follows)
- change the highlight decorator to better call out errors (2px underline instead of 1px dotted)

