### PR TITLE
remove a deprecated menu item; add documentation

### DIFF
--- a/lib/analysis/analysis_decorator.coffee
+++ b/lib/analysis/analysis_decorator.coffee
@@ -1,6 +1,7 @@
 {CompositeDisposable} = require 'atom'
 _ = require 'lodash'
 
+# Class to add underline decorations and gutter bullets for analysis errors.
 class AnalysisDecorator
   constructor: (@errors) ->
     @subscriptions = new CompositeDisposable()

--- a/lib/analysis/analysis_toolbar.coffee
+++ b/lib/analysis/analysis_toolbar.coffee
@@ -2,6 +2,8 @@ _ = require 'lodash'
 rivets = require 'rivets'
 Template = require '../templates/template'
 
+# A class to display the errors summary for the workspace
+# ("Dart Tools 91 issues"). Shown above the status line.
 class AnalysisToolbar
   @infoTypes = [
     'HINT',

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -80,8 +80,6 @@ class DartTools
     AutoCompletePlusProvider.analysisApi = @analysisApi
     # @dartExplorerComponent.enable()
 
-
-
     # Status updates for analysis server
     @analysisApi.on 'server.connected', =>
       success = '[dart-tools] The analysis server is now running.'
@@ -99,7 +97,6 @@ class DartTools
         detail: 'Go to Settings > Packages > Dart Tools to specify Dart SDK'
 
     # Commands
-
     atom.commands.add 'atom-workspace', 'dart-tools:format-code', =>
       Utils.whenEditor (editor) =>
         editor.save()

--- a/lib/info/problem_view.coffee
+++ b/lib/info/problem_view.coffee
@@ -3,6 +3,7 @@ rivets = require 'rivets'
 _ = require 'lodash'
 Template = require '../templates/template'
 
+# Display all the issues for the workspace in a new editor ("Dart: Problems").
 class ProblemView
   @uri: 'dart-tools://problem-view'
 

--- a/lib/info/quick_info_view.coffee
+++ b/lib/info/quick_info_view.coffee
@@ -3,6 +3,8 @@ rivets = require 'rivets'
 Template = require '../templates/template'
 _ = require 'lodash'
 
+# Display one (or a few) problems in a panel at the botto of the screen. This is
+# used to show the problems for the currently selected line in the editor.
 class QuickInfoView
   constructor: ->
     @subscriptions = new CompositeDisposable()

--- a/menus/dart-tools.cson
+++ b/menus/dart-tools.cson
@@ -4,8 +4,7 @@
   'submenu': [
     'label': 'Dart Tools'
     'submenu': [
-      'label': 'Analyze File'
-      'command': 'dart-tools:analyze-file'
+      {'label': 'SDK Info', 'command': 'dart-tools:sdk-info'}
     ]
   ]
 ]


### PR DESCRIPTION
- fix https://github.com/radicaled/dart-tools/issues/54
- add documentation to clarify what the different analysis views and classes are used for
- remove a menu item that no longer went anywhere; add in the `SDK Info` menu item