### PR TITLE
change the sdk info and pub dialogs to modal dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ General overhaul of the errors display:
   * change the look of the quick info view of a dart issue
   * change the highlight decorator to better call out errors (2px underline instead of 1px dotted)
 
+Other:
+  * Change the SDK and Pub dialogs to model dialogs
+
 # 0.9.11
 
 Features:

--- a/lib/info/quick_info_view.html
+++ b/lib/info/quick_info_view.html
@@ -1,4 +1,4 @@
-<atom-panel id='quick-info-view' class='from-bottom' rv-if="it.shouldShow < problems">
+<atom-panel id='quick-info-view' class='from-bottom'>
   <div class="padded">
     <div rv-each-problem="it.problems">
       <div class="badge inline-block" rv-badge="problem">

--- a/lib/pub/pub_status_view.coffee
+++ b/lib/pub/pub_status_view.coffee
@@ -4,20 +4,16 @@ Template = require '../templates/template'
 class PubStatusView
   @title        = ''
   @output       = ''
-  @shouldShow   = false
 
   constructor: (@pubComponent) ->
     element = Template.get('pub/pub_status_view.html')
-    atom.workspace.addBottomPanel(item: element)
+    @panel = atom.workspace.addModalPanel(item: element, visible: false)
     atom.commands.add 'atom-workspace', 'core:cancel', =>
-      @shouldShow = false
-
+      @panel.hide()
     @view = rivets.bind(element, {it: this})
-
     @listen()
 
   listen: =>
-
     asHtml = (input, textClass) =>
       textClass = '' unless textClass
       formatted = input.replace new RegExp('\n', 'g'), "<br>"
@@ -26,7 +22,7 @@ class PubStatusView
     @pubComponent.onPubStart (data) =>
       @title = data.title
       @output = ''
-      @shouldShow = true
+      @panel.show()
 
     @pubComponent.onPubUpdate (data) =>
       @output = @output + asHtml(data.output)
@@ -38,6 +34,6 @@ class PubStatusView
       @title = @title + ' (Finished)'
 
   hide: =>
-    @shouldShow = false
+    @panel.hide()
 
 module.exports = PubStatusView

--- a/lib/pub/pub_status_view.html
+++ b/lib/pub/pub_status_view.html
@@ -1,14 +1,11 @@
-<atom-panel class='overlay from-bottom pub-status' rv-if="it.shouldShow">
-  <div class="padded">
-    <div class="inset-panel">
-      <div class="panel-heading">
-        <div class='pull-right'>
-          <a href='#' class='icon icon-x' rel='dismiss' rv-on-click="it.hide"></a>
-        </div>
-        <h2 rv-text="it.title"></h2>
+<atom-panel class='model pub-status'>
+  <div class="inset-panel">
+    <div class="panel-heading">
+      <div class='pull-right'>
+        <a href='#' class='icon icon-x' rel='dismiss' rv-on-click="it.hide"></a>
       </div>
-      <div class="panel-body padded" rv-html="it.output">
+      <div rv-text="it.title" class="inline-block"></div>
     </div>
-  </div>
+    <div class="panel-body padded" rv-html="it.output"></div>
   </div>
 </atom-panel>

--- a/lib/sdk/sdk_info.coffee
+++ b/lib/sdk/sdk_info.coffee
@@ -11,25 +11,23 @@ class SdkInfo
     @view.show()
 
 class View
-  shouldShow: false
   sdkPath: null
   sdkVersion: null
 
   constructor: ->
     element = Template.get('sdk/sdk_info.html')
-    atom.workspace.addBottomPanel(item: element)
-
+    @panel = atom.workspace.addModalPanel(item: element, visible: false)
     @view = rivets.bind(element, {it: this})
-
     @listen()
 
   listen: =>
     atom.commands.add 'atom-text-editor', 'core:cancel', =>
-      @shouldShow = false
+      @panel.hide()
 
   hide: =>
-    @shouldShow = false
+    @panel.hide()
+
   show: =>
-    @shouldShow = true
+    @panel.show()
 
 module.exports = SdkInfo

--- a/lib/sdk/sdk_info.html
+++ b/lib/sdk/sdk_info.html
@@ -1,20 +1,14 @@
-<atom-panel class='overlay from-bottom' rv-if="it.shouldShow">
-  <div class="padded">
-    <div class="inset-panel">
-      <div class="panel-heading">
-        <div class='pull-right'>
-          <a href='#' class='icon icon-x' rel='dismiss' rv-on-click="it.hide"></a>
-        </div>
-        <h2>Dart SDK Information</h2>
+<atom-panel class='model'>
+  <div class="inset-panel">
+    <div class="panel-heading">
+      <div class='pull-right'>
+        <a href='#' class='icon icon-x' rel='dismiss' rv-on-click="it.hide"></a>
       </div>
-      <div class="panel-body padded">
-        <h3>SDK path</h3>
-        <p>{ it.sdkPath }</p>
-
-        <h3>SDK version</h3>
-        <p>{ it.sdkVersion }</p>
-      </div>
+      <div class="inline-block">Dart SDK Information</div>
     </div>
-  </div>
+    <div class="panel-body padded">
+      <p><strong>SDK path:</strong> {it.sdkPath}</p>
+      <p><strong>SDK version:</strong> {it.sdkVersion}</p>
+    </div>
   </div>
 </atom-panel>


### PR DESCRIPTION
- change the sdk info and pub dialogs to modal dialogs

This address an issue where we had several panels docked on the bottom with hidden contents. When hidden, the panels were 1 pixel high. This led to a really thick separator between the panel area and the editors.

before:

![screen shot 2015-05-26 at 8 53 22 am](https://cloud.githubusercontent.com/assets/1269969/7816694/b5dc6292-0384-11e5-8b2d-51b55d85e83b.png)

after:

![screen shot 2015-05-26 at 5 55 39 am](https://cloud.githubusercontent.com/assets/1269969/7816681/9f12ab8e-0384-11e5-8632-db2038b7e094.png)
