### PR TITLE
Try to locate the user's SDK path when none provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Features:
   * Now supports analyzing plain jane Dart files when possible.
+  * When launched from command shell, will try to locate Dart SDK on demand if
+    no Dart SDK has been explicitly configured.
 
 General overhaul of the errors display:
   * add a gutter bullet decoration for dart infos, warnings, and errors

--- a/lib/analysis_server.coffee
+++ b/lib/analysis_server.coffee
@@ -5,6 +5,7 @@ spawn = require('child_process').spawn
 path  = require 'path'
 StreamSplitter = require 'stream-splitter'
 Q = require 'q'
+SdkService = require './sdk/sdk_service'
 
 module.exports =
 class AnalysisServer
@@ -18,7 +19,7 @@ class AnalysisServer
 
   start: (analysisRoots) =>
     promiseMap = {}
-    sdkPath = Utils.dartSdkPath()
+    sdkPath = SdkService.getActiveSdkPath()
     atomConfigRoot = atom.getConfigDirPath()
     args = [
       path.join(sdkPath,

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -2,6 +2,7 @@
 Utils = require './utils'
 AutoCompletePlusProvider = require './autocomplete/provider'
 _ = require 'lodash'
+SdkService = require './sdk/sdk_service'
 
 class DartTools
   subscriptions: new CompositeDisposable()
@@ -91,7 +92,7 @@ class DartTools
       '
       atom.notifications.addWarning warning
 
-    unless atom.config.get 'dart-tools.dartSdkLocation'
+    unless SdkService.getActiveSdkPath()
       info = '[dart-tools] Dart SDK not specified, analysis_server not running.'
       atom.notifications.addInfo info,
         detail: 'Go to Settings > Packages > Dart Tools to specify Dart SDK'

--- a/lib/dart-tools.coffee
+++ b/lib/dart-tools.coffee
@@ -107,6 +107,11 @@ class DartTools
       Utils.dartSdkInfo (sdkInfo) =>
         @sdkInfo.showInfo(sdkInfo)
 
+    atom.commands.add 'atom-workspace', 'dart-tools:show-picker', =>
+      ProjectPicker = require './project/project_picker'
+      p = new ProjectPicker()
+      p.launch()
+
   dispose: =>
     @subscriptions?.dispose()
     @analysisComponent?.disable()

--- a/lib/platform/platform_service.coffee
+++ b/lib/platform/platform_service.coffee
@@ -1,0 +1,12 @@
+class PlatformService
+  @windowsCmdMap =
+    pub: 'pub.bat'
+    dart: 'dart.exe'
+
+  @getExecutable: (cmd) =>
+    isWin = /^win/.test(process.platform)
+    return cmd unless isWin
+    windowsCmd = @windowsCmdMap[cmd]
+    return windowsCmd or cmd
+
+module.exports = PlatformService

--- a/lib/project/project_picker.coffee
+++ b/lib/project/project_picker.coffee
@@ -1,0 +1,24 @@
+rivets = require 'rivets'
+Template = require '../templates/template'
+
+class ProjectPicker
+  launch: =>
+    @view = new View()
+    @view.shouldShow = true
+
+class View
+  shouldShow: false
+
+  constructor: ->
+    element = Template.get('project/project_picker.html')
+    atom.workspace.addTopPanel(item: element)
+    atom.commands.add 'atom-workspace', 'core:cancel', =>
+      @shouldShow = false
+
+    @view = rivets.bind(element, {it: this})
+
+    @listen()
+
+  listen: =>
+
+module.exports = ProjectPicker

--- a/lib/project/project_picker.html
+++ b/lib/project/project_picker.html
@@ -1,0 +1,10 @@
+<atom-panel class='modal'>
+    <div class='select-list'>
+      <atom-text-editor mini>User input</atom-text-editor>
+        <ol class='list-group'>
+            <li class='selected'>one</li>
+            <li>two</li>
+            <li>three</li>
+        </ol>
+    </div>
+</atom-panel>

--- a/lib/sdk/sdk_service.coffee
+++ b/lib/sdk/sdk_service.coffee
@@ -25,7 +25,8 @@ class SdkService
 
   @getCommandPath: (command) =>
     sdkPath = @getActiveSdkPath()
-    throw "No valid Dart SDK found; cannot execute #{command}" unless sdkPath
+    unless sdkPath
+      throw new Error("No valid Dart SDK found; cannot execute #{command}")
     dartCmd = PlatformService.getExecutable command
     execPath = path.join(sdkPath, 'bin', dartCmd)
 

--- a/lib/sdk/sdk_service.coffee
+++ b/lib/sdk/sdk_service.coffee
@@ -1,0 +1,32 @@
+fs    = require 'fs'
+path  = require 'path'
+which = require 'which'
+PlatformService = require '../platform/platform_service'
+
+class SdkService
+  @discoverSdkPath: =>
+    cmd = PlatformService.getExecutable 'dart'
+    cmdLocation = ''
+    try
+      cmdLocation = which.sync(cmd)
+    catch error
+      console.log 'Error:', error
+      return
+    # cmdLocation will be something like "/usr/local/opt/dart/bin/dart"
+    # we need to get to "/usr/local/opt/dart/"
+    path.join(cmdLocation, '..', '..')
+
+  @getActiveSdkPath: =>
+    configuredSdk = atom.config.get 'dart-tools.dartSdkLocation'
+    configuredSdk or
+      process.env.DART_SDK or
+      @discoverSdkPath() or
+      ''
+
+  @getCommandPath: (command) =>
+    sdkPath = @getActiveSdkPath()
+    throw "No valid Dart SDK found; cannot execute #{command}" unless sdkPath
+    dartCmd = PlatformService.getExecutable command
+    execPath = path.join(sdkPath, 'bin', dartCmd)
+
+module.exports = SdkService

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,36 +1,26 @@
 _ = require 'lodash'
 spawn = require('child_process').spawn
 path  = require 'path'
+SdkService        = require './sdk/sdk_service'
+PlatformService   = require './platform/platform_service'
 
 module.exports =
 class Utils
-  @windowsCmdMap =
-    pub: 'pub.bat'
-    dart: 'dart.exe'
-
+  # TODO: find and replace all instances with PlatformService.getExecutable
   @getExecutable: (cmd) =>
-    isWin = /^win/.test(process.platform)
-    return cmd unless isWin
-    windowsCmd = @windowsCmdMap[cmd]
-    return windowsCmd or cmd
+    PlatformService.getExecutable(cmd)
 
+  # TODO: find and replace all instances with SdkService.getActiveSdkPath
   @getExecPath: (cmd) =>
-    sdkPath = @dartSdkPath()
-    dartCmd = @getExecutable cmd
-    execPath = if sdkPath then path.join(sdkPath, 'bin', dartCmd) else dartCmd
+    SdkService.getCommandPath(cmd)
 
   @whenEditor: (fxn) =>
     editor = atom.workspace.getActiveTextEditor()
     fxn(editor) if editor
 
-  @dartSdkPath: =>
-    atom.config.get 'dart-tools.dartSdkLocation' or
-      process.env.DART_SDK or
-      ''
-
   @dartSdkInfo: (fxn) =>
     sdkInfo =
-      sdkPath: atom.config.get 'dart-tools.dartSdkLocation'
+      sdkPath: SdkService.getActiveSdkPath()
       envPath: process.env.DART_SDK
     if fxn
       @dartVersion (dartVersion) =>
@@ -83,6 +73,7 @@ class Utils
     process = window.process unless process
     if process
       execPath = @getExecPath 'dart'
+      return false unless execPath
       process = spawn execPath, ['--version']
 
       process.on 'exit', (code) =>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-atom-fork": "~0.10.0",
     "reactionary-atom-fork": "~0.9.0",
     "rivets": "^0.8.1",
-    "stream-splitter": "~0.3.0"
+    "stream-splitter": "~0.3.0",
+    "which": "^1.1.1"
   }
 }


### PR DESCRIPTION
SdkService.discoverSdkPath tries to find the user's SDK path by
examining their PATH. This only works on Windows (theoretically) and
Atom instances that are launched from the shell (and thus inherit the
shell's PATH).

Closes #60