### PR TITLE
Send the preferred line length to the analysis_server during formatting

### DIFF
--- a/lib/analysis_api/edit_api.coffee
+++ b/lib/analysis_api/edit_api.coffee
@@ -8,3 +8,4 @@ class EditAPI
       file: file
       selectionOffset: offset
       selectionLength: length
+      lineLength: atom.config.get('editor.preferredLineLength')


### PR DESCRIPTION
The parameter is "lineLength" according to the new API

Closes #44