### PR TITLE
Replace AddContentOverlay with ChangeContentOverlay.

### DIFF
--- a/lib/analysis_api.coffee
+++ b/lib/analysis_api.coffee
@@ -32,8 +32,12 @@ module.exports =
     updateFile: (path, contents) =>
       files = {}
       files[path] =
-        type: 'add'
-        content: contents
+        type: 'change'
+        edits: [
+          offset: 0
+          length: contents?.length || 0
+          replacement: contents
+        ]        
 
       @perform 'analysis.updateContent',
         {files}

--- a/lib/analysis_api.coffee
+++ b/lib/analysis_api.coffee
@@ -35,9 +35,9 @@ module.exports =
         type: 'change'
         edits: [
           offset: 0
-          length: contents?.length || 0
+          length: contents?.length or 0
           replacement: contents
-        ]        
+        ]
 
       @perform 'analysis.updateContent',
         {files}


### PR DESCRIPTION
According to the documentation, AddContentOverlay blows away the analysis_servers knowledge of the file and replaces it with the provided contents. However, when we use this in practice the analysis_server seems to completely forget about non-essential (hints, infos, warnings) errors. So now we do the same thing, but by using the ChangeContentOverlay instead.

Closes #74 (and several strange, unreported anamolies I noticed locally)