### PR TITLE
Made "//" the default comment start string.

### DIFF
--- a/settings/dart.cson
+++ b/settings/dart.cson
@@ -1,3 +1,3 @@
-".source.dart":
+'.source.dart':
   editor:
-    commentStart: "// "
+    commentStart: '// '

--- a/settings/dart.cson
+++ b/settings/dart.cson
@@ -1,0 +1,3 @@
+".source.dart":
+  editor:
+    commentStart: "// "


### PR DESCRIPTION
This commit modifies the string that is prepended when the command `editor:toggle-line-comments` in Atom is executed on Dart source code. The new string is `// `.