### PR TITLE
Added `enum` keyword to grammar.

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -194,7 +194,7 @@
         'name': 'keyword.control.new.dart'
       }
       {
-        'match': '\\b(abstract|class|extends|external|factory|implements|interface|get|native|operator|set|typedef)\\b'
+        'match': '\\b(abstract|class|enum|extends|external|factory|implements|interface|get|native|operator|set|typedef)\\b'
         'name': 'keyword.declaration.dart'
       }
       {


### PR DESCRIPTION
Very basic change. Just adds `enum` to the `keyword.declaration.dart` match.