### PR TITLE
Several small grammar edits

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -155,8 +155,10 @@
         'name': 'support.class.dart'
       }
       {
-        'match': '(_?[a-z][a-zA-Z]+)(?=\\\(\\\[)'
-        'name': 'entity.name.function.dart'
+        'match': '(_?[a-z][a-zA-Z]+)\\(.*\\)\\s*({|;|=>)'
+        'captures':
+          '1':
+            'name': 'entity.name.function.dart'
       }
       {
         'match': '\\b[A-Z_0-9]+\\b'

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -155,7 +155,7 @@
         'name': 'support.constant.dart'
       }
       {
-        'match': '\\b_?[A-Z][a-zA-Z]+\\b'
+        'match': '\\b_?[A-Z][a-zA-Z0-9]+\\b'
         'name': 'support.class.dart'
       }
       {

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -159,7 +159,7 @@
         'name': 'support.class.dart'
       }
       {
-        'match': '(_?[a-z][a-zA-Z]+)\\('
+        'match': '(_?[a-z][a-zA-Z0-9]+)\\('
         'captures':
           '1':
             'name': 'entity.name.function.dart'

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -159,7 +159,7 @@
         'name': 'support.class.dart'
       }
       {
-        'match': '(_?[a-z][a-zA-Z]+)\\s*\\('
+        'match': '(_?[a-z][a-zA-Z]+)\\('
         'captures':
           '1':
             'name': 'entity.name.function.dart'

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -194,7 +194,7 @@
         'name': 'keyword.control.new.dart'
       }
       {
-        'match': '\\b(abstract|class|extends|external|factory|implements|interface|get|native|operator|set|typedef)\\b'
+        'match': '\\b(abstract|class|enum|extends|external|factory|implements|interface|get|native|operator|set|typedef)\\b'
         'name': 'keyword.declaration.dart'
       }
       {

--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -159,7 +159,7 @@
         'name': 'support.class.dart'
       }
       {
-        'match': '(_?[a-z][a-zA-Z]+)\\(.*\\)\\s*({|;|=>)'
+        'match': '(_?[a-z][a-zA-Z]+)\\s*\\('
         'captures':
           '1':
             'name': 'entity.name.function.dart'


### PR DESCRIPTION
* Fixed highlighting of function names
* Added `enum`
* Allow constants to be preceded with an underscore and be one word
* Remove triple equals
* Lowercase `dynamic`
* Removed `String` from primitive types
