### PR TITLE
Update dart.cson

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -83,7 +83,7 @@
     'patterns': [
       {
         'begin': '/\\*\\*'
-        'end': '\\*\\*/'
+        'end': '\\*/'
         'name': 'comment.block-dartdoc.dart'
         'patterns': [
           {


### PR DESCRIPTION
Fixed an issue where dartdoc comments would only terminate  `**/` and not  `*/`.