### PR TITLE
No need to manually refresh linter view anymore.

### DIFF
--- a/lib/linter/linter_component.coffee
+++ b/lib/linter/linter_component.coffee
@@ -37,7 +37,6 @@ class LinterComponent
 
       @linter.deleteProjectMessages(linterConfig)
       @linter.setProjectMessages linterConfig, messages
-      @linter.views.render()
 
     @errorRepository.onChange _.debounce(updateErrors, 250, maxWait: 1000)
 


### PR DESCRIPTION
deleteProjectMessages / setProjectMessages interface now does this for us.