### PR TITLE
Fix call order of consumeLinter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.19
+
+Bugfixes:
+  * Fix issue with method call order related to `linter` integration (20f760)  
+
 # 0.9.18
 
 Features:


### PR DESCRIPTION
This issue is complicated by the fact that call order seems to be static (activate, then call consumeLinter) in dev mode but seemingly random in production mode.